### PR TITLE
upgrade proguard from 4.2 to 5.2.1, compiles on JDK 1.8

### DIFF
--- a/microemulator/api/cldcapi10/pom.xml
+++ b/microemulator/api/cldcapi10/pom.xml
@@ -43,9 +43,9 @@
             </plugin>
 
             <plugin>
-                <groupId>com.pyx4me</groupId>
+                <groupId>com.github.wvengen</groupId>
                 <artifactId>proguard-maven-plugin</artifactId>
-                <version>${pyx4meVersion}</version>
+                <version>2.0.14</version>
                 <executions>
                    <execution>
                        <phase>package</phase>

--- a/microemulator/api/cldcapi11/pom.xml
+++ b/microemulator/api/cldcapi11/pom.xml
@@ -43,9 +43,9 @@
             </plugin>
 
             <plugin>
-                <groupId>com.pyx4me</groupId>
+                <groupId>com.github.wvengen</groupId>
                 <artifactId>proguard-maven-plugin</artifactId>
-                <version>${pyx4meVersion}</version>
+                <version>2.0.14</version>
                 <executions>
                    <execution>
                        <phase>package</phase>

--- a/microemulator/api/midpapi20/pom.xml
+++ b/microemulator/api/midpapi20/pom.xml
@@ -53,9 +53,9 @@
             </plugin>
 
             <plugin>
-                <groupId>com.pyx4me</groupId>
+                <groupId>com.github.wvengen</groupId>
                 <artifactId>proguard-maven-plugin</artifactId>
-                <version>${pyx4meVersion}</version>
+                <version>2.0.14</version>
                 <executions>
                    <execution>
                        <phase>package</phase>

--- a/microemulator/microemu-cldc/pom.xml
+++ b/microemulator/microemu-cldc/pom.xml
@@ -39,9 +39,9 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.pyx4me</groupId>
+                <groupId>com.github.wvengen</groupId>
                 <artifactId>proguard-maven-plugin</artifactId>
-                <version>${pyx4meVersion}</version>
+                <version>2.0.14</version>
                 <executions>
                    <execution>
                        <phase>package</phase>

--- a/microemulator/microemu-javase-applet/pom.xml
+++ b/microemulator/microemu-javase-applet/pom.xml
@@ -106,9 +106,9 @@
 
             <!-- applet jar-with-dependencies -->
             <plugin>
-                <groupId>com.pyx4me</groupId>
+                <groupId>com.github.wvengen</groupId>
                 <artifactId>proguard-maven-plugin</artifactId>
-                <version>${pyx4meVersion}</version>
+                <version>2.0.14</version>
                 <executions>
                    <execution>
                        <phase>package</phase>

--- a/microemulator/microemu-midp/pom.xml
+++ b/microemulator/microemu-midp/pom.xml
@@ -44,9 +44,9 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.pyx4me</groupId>
+                <groupId>com.github.wvengen</groupId>
                 <artifactId>proguard-maven-plugin</artifactId>
-                <version>${pyx4meVersion}</version>
+                <version>2.0.14</version>
                 <executions>
                    <execution>
                        <phase>package</phase>

--- a/microemulator/pom.xml
+++ b/microemulator/pom.xml
@@ -63,7 +63,7 @@
         <module>microemu-injected</module>
         <module>microemu-javase</module>
         <module>microemu-javase-swing</module>
-        <module>microemu-javase-applet</module>
+<!--        <module>microemu-javase-applet</module>-->
         <!-- only buildByMicroEmulatorTeam edit settings.xml to enable -->
         <!--module>microemu-javase-swt</module-->
         <module>microemu-extensions</module>


### PR DESCRIPTION
I have disabled the microemu-javase-applet module, it is the only module which doesn't work with proguard 5.2.1